### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ COPY src/df-types/ ./build/src/df-types/
 FROM node:10
 
 WORKDIR /app
-COPY --from=builder package.json tsconfig.json .env setup-ipfs.sh ./
+COPY --from=builder package.json tsconfig.json .env setup-ipfs.sh yarn.lock ./
 COPY --from=builder build/ ./build
 COPY --from=builder node_modules/ ./node_modules
 


### PR DESCRIPTION
Force copy of yarn.lock to prevent js-ipfs@^0.40.0 error