### PR TITLE
Specify concrete version Subsocial libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "devDependencies": {
     "@polkadot/types": "1.28.1",
     "@subsocial/config": "^0.4.12",
-    "@subsocial/types": "latest",
-    "@subsocial/utils": "latest",
+    "@subsocial/types": "^0.4.13",
+    "@subsocial/utils": "^0.4.13",
     "@types/axios": "^0.14.0",
     "@types/bn.js": "^4.11.5",
     "@types/connect-timeout": "^0.0.34",
@@ -54,8 +54,7 @@
   "license": "GPL-3.0-only",
   "dependencies": {
     "@elastic/elasticsearch": "^7.4.0",
-    "@subsocial/api": "latest",
-    "@subsocial/utils": "latest",
+    "@subsocial/api": "^0.4.13",
     "axios": "^0.19.0",
     "bn.js": "^4.11.8",
     "body-parser": "^1.18.3",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "test": "jest --coverage",
     "test:watch": "jest --watch",
     "setup": "yarn init-offchain && yarn build",
-    "reindex-content": "node ./build/src/search/reindexer.js",
-    "update": "yarn cache clean --force && yarn"
+    "reindex-content": "node ./build/src/search/reindexer.js"
   },
   "author": "DappForce contributors",
   "license": "GPL-3.0-only",

--- a/yarn.lock
+++ b/yarn.lock
@@ -571,10 +571,10 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@subsocial/api@latest":
-  version "0.4.11"
-  resolved "https://registry.yarnpkg.com/@subsocial/api/-/api-0.4.11.tgz#e9b1889379414c4870649139dfe65218a5b9e0ca"
-  integrity sha512-pDzuWJVRsW9RnkMv5SNidGxjzcUUkKYz2T2cZTv7JBB/upS+0m0YJjiNV2xKwSgYF5ATLTpptSIXlYQTEqT5Kw==
+"@subsocial/api@^0.4.13":
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/@subsocial/api/-/api-0.4.13.tgz#293dfb982227e541a47c4195417e463538db59b1"
+  integrity sha512-+f9h0D6+iczYEgByIqwD8LEa/W5y3b3tfylTAdh/QFxRYAsvfjDwgoW1rYjgP6B5m/wmFEnuTjRbLff9DEWwUQ==
   dependencies:
     "@polkadot/api" "1.28.1"
     "@subsocial/utils" latest
@@ -585,13 +585,26 @@
   resolved "https://registry.yarnpkg.com/@subsocial/config/-/config-0.4.12.tgz#7c9be7e31312c790771003186df9e828a21adc3e"
   integrity sha512-f7glrTz+qKMy2G0dn3bOKh4VJd/xcHRz9jvLYI2kKOPNsEoKBKNPi8n7CMUQC3ElIOirpTGfwfjjfP0p3jVX+w==
 
-"@subsocial/types@latest":
-  version "0.4.12"
-  resolved "https://registry.yarnpkg.com/@subsocial/types/-/types-0.4.12.tgz#b5c1ab8d56a71fd0a4aa2c4feacee0142f0e0e08"
-  integrity sha512-A9T65BELtW6/MZzYXqivmAYyDFPQE6A1wRbE7q6aZr3y7neGxWq6Me9OBK+DcjlOWa2MBocQknGd4qnlvK7AIg==
+"@subsocial/types@^0.4.13":
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/@subsocial/types/-/types-0.4.13.tgz#a6ea6e5529a2c7657ae43157315212560ab513f4"
+  integrity sha512-NfUZTM/NoNakO2wirFGYOozJSixxxeoJuGSkThmVihuVCJDAx1vV3Pf5AtSq+zs7/FebhR8Pp6aDIlqyXwHmxA==
   dependencies:
     "@subsocial/utils" latest
     cids "^0.7.1"
+
+"@subsocial/utils@^0.4.13":
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/@subsocial/utils/-/utils-0.4.13.tgz#638898e8ac642eb89b5fdf594f5d08f95b70dfa7"
+  integrity sha512-j+CHLGBQK/Np6D8dpWWe46uq6uW38YyKG/CLXzJa7lNZz5XYLkBwy1jG3rcMGiyMw3oGP7gux6m27RrTUZbO4Q==
+  dependencies:
+    bn.js "^5.1.1"
+    chalk "^3.0.0"
+    dotenv "^8.0.0"
+    lodash.isempty "^4.4.0"
+    lodash.truncate "^4.4.2"
+    loglevel "^1.7.0"
+    loglevel-plugin-prefix "^0.8.4"
 
 "@subsocial/utils@latest":
   version "0.4.11"


### PR DESCRIPTION
`latest` specification is ok when actively developing within one commit.
When pushing, it's better to have the exact version of libs in `package.json`, because the newest can be incompatible with the one needed in the specific commit.